### PR TITLE
ci(labeler): fix the labeler token and use canonical label names

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,16 +1,15 @@
-documentation 📝:
+type:docs:
   - "docs/**/*.md"
   - "community/**/*.md"
   - "ecosystem/**/*.md"
-dependencies 📦:
+area:dependencies:
   - "package.json"
   - "pnpm-lock.yaml"
   - "yarn.lock"
-enhancement ✨:
+type:maintenance:
   - "functions/**"
   - "src/**"
   - "lib/**"
-maintenance 📈:
   - ".all-contributorsrc"
   - ".deepsource.toml"
   - ".editorconfig"
@@ -33,16 +32,7 @@ maintenance 📈:
   - "crowdin.yml"
   - "netlify.toml"
   - "tsconfig.json"
-i18n 🌐:
-  - "i18n/**"
-  - "docs/i18n/**"
-annex 🌀:
+area:annex:
   - "*"
-#package 📦:
-#  - 'ecosystem/packages/**/*.md'
-#  - 'i18n/**/docusaurus-plugin-content-ecosystem/**/packages/**/*.md'
-#plugin ⚙️:
-#  - 'ecosystem/plugins/**.md'
-#  - 'i18n/**/docusaurus-plugin-content-ecosystem/**/plugins/**/*.md'
-ci 🤖:
+area:ci:
   - ".github/workflows/*"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -13,5 +13,5 @@ jobs:
     steps:
       - uses: actions/labeler@v4
         with:
-          repo-token: "${{ secrets.GH_PAT }}"
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
           sync-labels: false


### PR DESCRIPTION
Two related fixes to the pull request labeler, kept together deliberately.

## 1. The labeler could never authenticate

`repo-token` came from `secrets.GH_PAT`, which is not populated, so `actions/labeler` failed before reading any configuration:

```
##[error]Error: Parameter token or opts.auth is required
```

No PAT is needed. The job already declares `pull-requests: write`, the only permission `actions/labeler` requires for a same-repository pull request, so the default `GITHUB_TOKEN` is sufficient and drops a long-lived credential dependency.

## 2. The config named labels that no longer exist

`.github/labeler.yml` referenced legacy labels that [z-shell/.github#467](https://github.com/z-shell/.github/issues/467) deleted across the organization:

| Was | Now |
| --- | --- |
| `documentation 📝` | `type:docs` |
| `dependencies 📦` | `area:dependencies` |
| `enhancement ✨` | `type:maintenance` |
| `maintenance 📈` | `type:maintenance` |
| `annex 🌀` / `plugin ⚙️` / `package 📦` | `area:annex` / `area:plugin` / `area:package` |
| `ci 🤖` | `area:ci` |
| `i18n 🌐` | removed |

## Why both in one pull request

These must not land separately. `actions/labeler` applies labels through the issues API, which **creates** a label that does not exist rather than failing. Fixing the token alone would make the labeler start working while it still names deleted labels, resurrecting them on the next matching pull request and undoing the org-wide cleanup. Fixing the config alone leaves the labeler broken. Together they are safe in either merge order.

Two notes on the config change:

- **`enhancement ✨` and `maintenance 📈` both map to `type:maintenance`**, so their glob lists merge into one key rather than being renamed one for one.
- **`i18n 🌐` is dropped, not translated.** It has no canonical equivalent and this repository has never used it. The only repository in the organization that does is `z-shell/wiki`, which does not drive it from a labeler config. It arrived here from a Docusaurus-shaped template, which is also why the config carried `crowdin.yml` and `i18n/**` globs for paths this repository does not have.

## Verified before fan-out

Piloted in `z-shell/z-a-submods`. After the identical changes merged, [z-a-submods#7](https://github.com/z-shell/z-a-submods/pull/7) was the first pull request to run against them: the `triage` check succeeded where every previous run had failed, and the labeler applied `area:ci`, correctly matched and canonical.

The `triage` check on **this** pull request is still expected to fail, because `pull_request_target` runs the workflow from the base branch, which still has the broken token. That is not a regression and not a reason to hold the merge; the fix takes effect for the first pull request opened after this merges.

Part of z-shell/.github#527.
